### PR TITLE
Dist zilla next

### DIFF
--- a/t/corpus/dist-zilla.changes
+++ b/t/corpus/dist-zilla.changes
@@ -1,0 +1,11 @@
+Revision history for Catalyst-Plugin-Sitemap
+
+{{$NEXT}}
+    - Something
+
+1.0.0     2010-11-30
+    - Change sitemap object under the hood to WWW::Sitemap::XML.
+    - Add Dancer::Plugin::SiteMap in the 'SEE ALSO' section.
+
+0.0.1     2010-09-29
+    - original version unleashed on an unsuspecting world

--- a/t/dist-zilla-changes.t
+++ b/t/dist-zilla-changes.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Test::More tests => 17;
+
+use_ok( 'CPAN::Changes' );
+
+my $changes = CPAN::Changes->load( 't/corpus/dist-zilla.changes',
+    next_token => qr/{{\$NEXT}}/);
+
+isa_ok( $changes, 'CPAN::Changes' );
+is( $changes->preamble, 'Revision history for Catalyst-Plugin-Sitemap',
+    'preamble' );
+
+my @releases = $changes->releases;
+
+is( scalar @releases, 3, 'has 3 releases' );
+
+my $r = pop @releases;
+
+isa_ok( $r, 'CPAN::Changes::Release' );
+is( $r->version, '{{$NEXT}}',       'version' );
+is( $r->date,    undef, 'date' );
+is_deeply(
+    $r->changes,
+    { '' => [ 'Something' ] },
+    'full changes'
+);
+is_deeply( [ $r->groups ], [ '' ], 'only the main group' );
+
+isa_ok( $releases[ 0 ], 'CPAN::Changes::Release' );
+is( $releases[ 0 ]->version, '0.0.1',      'version' );
+is( $releases[ 0 ]->date,    '2010-09-29', 'date' );
+is_deeply(
+    $releases[ 0 ]->changes,
+    { '' => [ 'original version unleashed on an unsuspecting world' ] },
+    'full changes'
+);
+is_deeply( [ $releases[ 0 ]->groups ], [ '' ], 'only the main group' );
+
+isa_ok( $releases[ 1 ], 'CPAN::Changes::Release' );
+is( $releases[ 1 ]->version, '1.0.0',      'version' );
+is( $releases[ 1 ]->date,    '2010-11-30', 'date' );
+


### PR DESCRIPTION
This is less of a pull request, and more of a review request.  Just want to know if you like the idea before I begin to amend the POD for my changes. 

Basically, I've added the possibility to declare a $next_token so that CPAN::Changes can also operate on "in progress" Changes files like the one Dist::Zilla churns.  As you might suspect, the end-goal is to align the stars so that 'I'll be able to use CPAN::Changes in Dist::Zilla plugins and other development-side tools. :-)
