### PR TITLE
add 'delete_empty_groups' methods

### DIFF
--- a/lib/CPAN/Changes.pm
+++ b/lib/CPAN/Changes.pm
@@ -203,6 +203,12 @@ sub release {
     return $self->{ releases }->{ $version };
 }
 
+sub delete_empty_groups {
+    my $self = shift;
+
+    $_->delete_empty_groups for $self->releases;
+}
+
 sub serialize {
     my $self = shift;
 
@@ -319,6 +325,10 @@ matching release object, undef is returned.
 
 Returns all of the data as a string, suitable for saving as a Changes 
 file.
+
+=head2 delete_empty_groups( )
+
+Deletes change groups without changes in all releases.
 
 =head1 DEALING WITH "NEXT VERSION" PLACEHOLDERS
 

--- a/lib/CPAN/Changes/Release.pm
+++ b/lib/CPAN/Changes/Release.pm
@@ -93,6 +93,14 @@ sub delete_group {
     delete $self->{ changes }->{ $_ } for @groups;
 }
 
+sub delete_empty_groups {
+    my $self = shift;
+
+    $self->delete_group(
+        grep { ! @{ $self->changes($_) } } $self->groups
+    );
+}
+
 sub serialize {
     my $self = shift;
 
@@ -196,6 +204,10 @@ Creates an empty group under the names provided.
 =head2 delete_group( @groups )
 
 Deletes the groups of changes specified.
+
+=head2 delete_empty_groups( )
+
+Deletes all groups that don't contain any changes.
 
 =head2 serialize( )
 

--- a/t/delete_empty_groups.t
+++ b/t/delete_empty_groups.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use CPAN::Changes;
+
+my $changes = CPAN::Changes->load_string(<<'END_CHANGES');
+0.2 2012-02-01
+    [D]
+    [E]
+    - Yadah
+
+0.1 2011-01-01
+    [A]
+    - Stuff
+    [B]
+    [C]
+    - Blah
+END_CHANGES
+
+$changes->delete_empty_groups;
+
+is_deeply( [ sort( ($changes->releases)[0]->groups ) ], [ qw/ A C / ] );
+is_deeply( [ sort( ($changes->releases)[1]->groups ) ], [ 'E' ] );
+
+


### PR DESCRIPTION
Can be useful for sanitization (sp?) of Changelogs. For example,
the work copy of the changelog can contain all the acceptable
groups, and we might want to filter away those that weren't used
for a specific release.

And just to throw in alternatives: we could instead have a 'skip_empty_groups' argument for the 'serialize()' method.
