### PR TITLE
add the option to sort groups

### DIFF
--- a/lib/CPAN/Changes.pm
+++ b/lib/CPAN/Changes.pm
@@ -246,11 +246,16 @@ sub delete_empty_groups {
 
 sub serialize {
     my $self = shift;
+    my %args = @_;
+
+    my %release_args;
+    $release_args{groups_sort} = $args{groups_sort} if $args{groups_sort};
 
     my $output;
 
     $output = $self->preamble . "\n\n" if $self->preamble;
-    $output .= join( "\n", $_->serialize ) for reverse $self->releases;
+    $output .= join "\n", $_->serialize( %release_args ) 
+        for reverse $self->releases;
 
     return $output;
 }
@@ -356,10 +361,14 @@ Deletes all of the releases specified by the versions supplied to the method.
 Returns the release object for the specified version. Should there be no 
 matching release object, undef is returned.
 
-=head2 serialize( )
+=head2 serialize( groups_sort => \&sorting_function )
 
 Returns all of the data as a string, suitable for saving as a Changes 
 file.
+
+If I<groups_sort> is provided, change groups are
+sorted according to the given function. If not,
+groups are sorted alphabetically.
 
 =head2 delete_empty_groups( )
 

--- a/lib/CPAN/Changes/Release.pm
+++ b/lib/CPAN/Changes/Release.pm
@@ -76,7 +76,11 @@ sub clear_changes {
 
 sub groups {
     my $self = shift;
-    return sort keys %{ $self->{ changes } };
+    my %args = @_;
+
+    $args{sort} ||= sub { sort @_ };
+
+    return $args{sort}->(keys %{ $self->{ changes } });
 }
 
 sub add_group {
@@ -103,11 +107,13 @@ sub delete_empty_groups {
 
 sub serialize {
     my $self = shift;
+    my %args = @_;
 
     my $output = sprintf "%s %s\n", $self->version, $self->date;
 
     $output
-        .= join( "\n", map { $self->_serialize_group( $_ ) } $self->groups );
+        .= join "\n", map { $self->_serialize_group( $_ ) } 
+                      $self->groups( sort => $args{groups_sort} );
     $output .= "\n";
 
     return $output;
@@ -193,9 +199,13 @@ a C<group> option will only replace change items in that group.
 
 Clears all changes from the release.
 
-=head2 groups( )
+=head2 groups( sort => \&sorting_function )
 
 Returns a list of current groups in this release.
+
+If I<sort> is provided, groups are
+sorted according to the given function. If not,
+they are sorted alphabetically.
 
 =head2 add_group( @groups )
 
@@ -209,10 +219,14 @@ Deletes the groups of changes specified.
 
 Deletes all groups that don't contain any changes.
 
-=head2 serialize( )
+=head2 serialize( groups_sort => \&sorting_function )
 
 Returns the release data as a string, suitable for inclusion in a Changes 
 file.
+
+If I<groups_sort> is provided, change groups are
+sorted according to the given function. If not,
+groups are sorted alphabetically.
 
 =head1 SEE ALSO
 

--- a/t/sort_groups.t
+++ b/t/sort_groups.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+
+use CPAN::Changes;
+
+my $changes = CPAN::Changes->load_string(<<'END_CHANGES');
+2011-04-17 1.05
+    [A]
+    - stuff
+    [B]
+    - mo' stuff
+2011-04-16 1.04
+    [C]
+    - stuff
+    [D]
+    - mo' stuff
+END_CHANGES
+
+like $changes->serialize => expected_order(qw/ A B C D/ );
+like $changes->serialize( groups_sort => \&reverse_order ) => expected_order(qw/ B A D C/ );
+
+my ($release) = reverse $changes->releases;
+like $release->serialize => expected_order(qw/ A B / );
+like $release->serialize( groups_sort => \&reverse_order ) => expected_order(qw/ B A / );
+
+is_deeply [ $release->groups ], [qw/ A B /]; 
+is_deeply [ $release->groups( sort => \&reverse_order ) ], [qw/ B A /]; 
+
+sub reverse_order {
+    return reverse sort @_;
+}
+
+sub expected_order {
+    my @groups = @_;
+    my $re = join '.*', map { "\\[$_\\]" } @groups;
+    return qr/$re/s;
+}


### PR DESCRIPTION
Me again. :-)

By the default, the current ordering (alphanumerical) is kept, but I'm adding the possibility to provide a different sorting function.

An example where this comes handy is when groups are not all of equal importance. In my modules, I want the 'API CHANGES' to be shown first, then the 'ENHANCEMENTS' and then the 'BUG FIXES'.
