### PR TITLE
Add $VERSION to Test::CPAN::Changes so it plays nice with the toolchain.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl module CPAN::Changes
 
+  - Add $VERSION to Test::CPAN::Changes so it plays nice with the toolchain
+    e.g Module::Install::AuthorRequres (Dan Brook)
+
 0.17 2011-04-21
 
   - Eliminate extra whitespace when release date is not defined (RT #67441)

--- a/lib/Test/CPAN/Changes.pm
+++ b/lib/Test/CPAN/Changes.pm
@@ -7,6 +7,8 @@ use CPAN::Changes;
 use Test::Builder;
 use version ();
 
+our $VERSION = '0.17';
+
 my $Test       = Test::Builder->new;
 
 sub import {


### PR DESCRIPTION
e.g Module::Install::AuthorRequres. I stumbled across this when I was trying
to integrate Test::CPAN::Changes into the Gitalist authors tests and
Module::Install::AuthorRequres would invoke VERSION on Test::CPAN::Changes
which threw an exception[0] and therefore considered the dep unsatisfied[1].

If this makes it to CPAN I'll see to integrating Test::CPAN::Changes into the author tests for Gitalist and in the mean time I'll run the test manually :)

Cheers,
Dan Brook aka broquaint

[0] http://paste.scsys.co.uk/106317
[1] http://paste.scsys.co.uk/106318
