### PR TITLE
don't delete '' group by mistake

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl module CPAN::Changes
 
+{{$NEXT}}
+  - 'delete_empty_groups' don't erronously delete default group. 
+
+
 0.19 2012-04-30
 
   - Test::CPAN::Changes now accepts version entries ending in '-TRIAL' (RT

--- a/lib/CPAN/Changes/Release.pm
+++ b/lib/CPAN/Changes/Release.pm
@@ -100,7 +100,8 @@ sub delete_group {
 sub delete_empty_groups {
     my $self = shift;
 
-    $self->delete_group( grep { !@{ $self->changes( $_ ) } } $self->groups );
+    $self->delete_group($_) 
+        for grep { !@{ $self->changes( $_ ) } } $self->groups;
 }
 
 sub serialize {

--- a/t/delete_empty_groups.t
+++ b/t/delete_empty_groups.t
@@ -5,7 +5,10 @@ use Test::More tests => 2;
 
 use CPAN::Changes;
 
-my $changes = CPAN::Changes->load_string(<<'END_CHANGES');
+subtest basic => sub {
+    plan tests => 2;
+
+    my $changes = CPAN::Changes->load_string(<<'END_CHANGES');
 0.2 2012-02-01
     [D]
     [E]
@@ -19,9 +22,31 @@ my $changes = CPAN::Changes->load_string(<<'END_CHANGES');
     - Blah
 END_CHANGES
 
-$changes->delete_empty_groups;
+    $changes->delete_empty_groups;
 
-is_deeply( [ sort( ($changes->releases)[0]->groups ) ], [ qw/ A C / ] );
-is_deeply( [ sort( ($changes->releases)[1]->groups ) ], [ 'E' ] );
+    is_deeply( [ sort( ($changes->releases)[0]->groups ) ], [ qw/ A C / ] );
+    is_deeply( [ sort( ($changes->releases)[1]->groups ) ], [ 'E' ] );
+};
 
+subtest mixed => sub {
+    plan tests => 1;
 
+    my $changes = CPAN::Changes->load_string(<<'END_CHANGES');
+Revision history for {{$dist->name}}
+
+0.2.0
+    [BUGS FIXES]
+    - A
+    - B
+
+0.1.0     2012-03-19
+    - C
+END_CHANGES
+
+    $changes->delete_empty_groups;
+
+    is_deeply( [ sort( ($changes->releases)[0]->changes ) ], [ { 
+        '' => [ 'C' ],
+    } ] );
+
+};


### PR DESCRIPTION
If the "delete_empty_groups" has no group to delete, its call to "delete_group" was defaulting to delete the empty string group. ooops.
