### PR TITLE
must escape { in regex in 5.22

### DIFF
--- a/t/dist-zilla-changes.t
+++ b/t/dist-zilla-changes.t
@@ -6,7 +6,7 @@ use Test::More;
 use CPAN::Changes;
 
 my $changes = CPAN::Changes->load( 't/corpus/dist-zilla.changes',
-    next_token => qr/{{\$NEXT}}/);
+    next_token => qr/\{\{\$NEXT\}\}/);
 
 isa_ok( $changes, 'CPAN::Changes' );
 is( $changes->preamble, 'Revision history for Catalyst-Plugin-Sitemap',


### PR DESCRIPTION
... or we get a bunch of warnings.
