### PR TITLE
Fixing 'Use of uninitialized value' warning.

### DIFF
--- a/lib/CPAN/Changes.pm
+++ b/lib/CPAN/Changes.pm
@@ -144,8 +144,8 @@ sub load_string {
                 $n =~ s{^\Q$match\E\s*}{};
             }
 
-            undef $d unless length $d;
-            undef $n unless length $n;
+            undef $d unless (defined $d && length $d);
+            undef $n unless (defined $n && length $n);
 
             push @releases,
                 CPAN::Changes::Release->new(


### PR DESCRIPTION
Hi,

Please review the above change. It tries to remove the above warning. I noticed the warning during the build process of Dancer::Template::Handlebars as below:

manwar@ubuntu:~/Dancer-Template-Handlebars$ dzil build
[DZ] beginning to build Dancer-Template-Handlebars
Use of uninitialized value $d in length at /usr/local/share/perl/5.10.1/CPAN/Changes.pm line 147, <DATA> line 22.
Use of uninitialized value $n in length at /usr/local/share/perl/5.10.1/CPAN/Changes.pm line 148, <DATA> line 22.
Use of uninitialized value $d in length at /usr/local/share/perl/5.10.1/CPAN/Changes.pm line 147, <DATA> line 22.
Use of uninitialized value $n in length at /usr/local/share/perl/5.10.1/CPAN/Changes.pm line 148, <DATA> line 22.

Best Regards,
Mohammad S Anwar
