### PR TITLE
Make tidy_changelog work as a pipe with input '-'

### DIFF
--- a/lib/CPAN/Changes.pm
+++ b/lib/CPAN/Changes.pm
@@ -46,7 +46,14 @@ sub new {
 sub load {
     my ( $class, $file, @args ) = @_;
 
-    open( my $fh, '<:raw', $file ) or die $!;
+    my $fh;
+    if ( $file eq '-' ) {
+        open( $fh, '<-' ) or die $!;
+        binmode($fh)
+    }
+    else {
+        open( $fh, '<:raw', $file ) or die $!;
+    }
 
     my $content = do { local $/; <$fh> };
 

--- a/t/tidy_changelog.t
+++ b/t/tidy_changelog.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+{ # use filename
+    my $tidy_changes = qx{$^X -Ilib bin/tidy_changelog t/corpus/basic.changes};
+
+    is( $tidy_changes, <<"    EOTIDY", "output correct (filename)" );
+0.01 2010-06-16
+ - Initial release
+    EOTIDY
+}
+
+{ # use filtermode
+    my $basic_changes = do { local (@ARGV, $/) = ('t/corpus/basic.changes'); <> };
+    open( my $pipe, '|-', "$^X -Ilib bin/tidy_changelog - > pipe_basic.changes" ) or die "Cannot fork: $!";
+    print $pipe $basic_changes;
+    close( $pipe );
+
+    my $tidy_changes = do { local (@ARGV, $/) = ('pipe_basic.changes'); <> };
+    is( $tidy_changes, <<"    EOTIDY", "output correct (pipe)" );
+0.01 2010-06-16
+ - Initial release
+    EOTIDY
+
+    unlink 'pipe_basic.changes';
+}
+
+done_testing();


### PR DESCRIPTION
This patch makes it possible to use ```tidy_changelog`` as a filter (pipe) when input file '-' is used.