### PR TITLE
Update prereqs: version::is_lax was introduced in 0.80

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ my %META = (
         'Test::Builder' => 0,
         'Sub::Quote' => '1.005000',
         'Types::Standard' => 0,
+        'version' => '0.80',
       },
     },
     develop => {

--- a/lib/Test/CPAN/Changes.pm
+++ b/lib/Test/CPAN/Changes.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use CPAN::Changes::Parser;
 use Test::Builder;
-use version ();
+use version 0.80 ();
 
 our $VERSION = '0.500004';
 $VERSION =~ tr/_//d;


### PR DESCRIPTION
Test::CPAN::Changes uses version::is_lax. A compatible version.pm wasn't available in a perl maintenance release until perl v5.12.0, so earlier perls need to upgrade version.pm to use this module.