### PR TITLE
Skip Pod coverage test if Test::Pod::Coverage::TrustMe is not there

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ my %META = (
         'Test::Builder' => 0,
         'Sub::Quote' => '1.005000',
         'Types::Standard' => 0,
+        'version' => '0.80',
       },
     },
     develop => {

--- a/lib/Test/CPAN/Changes.pm
+++ b/lib/Test/CPAN/Changes.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use CPAN::Changes::Parser;
 use Test::Builder;
-use version ();
+use version 0.80 ();
 
 our $VERSION = '0.500004';
 $VERSION =~ tr/_//d;

--- a/xt/author/pod_coverage.t
+++ b/xt/author/pod_coverage.t
@@ -1,2 +1,5 @@
-use Test::Pod::Coverage::TrustMe;
+use Test::More;
+eval "use Test::Pod::Coverage::TrustMe";
+plan skip_all => "Test::Pod::Coverage::TrustMe required for testing pod coverage" if $@;
+plan tests => 1;
 all_pod_coverage_ok($_, { require_link => 1 });


### PR DESCRIPTION
This is similar to what other Test::Pod::* modules recommend for handling missing modules.