### PR TITLE
Skip pod coverage test if Test::Pod::Coverage::TrustMe is not installed

### DIFF
--- a/xt/author/pod_coverage.t
+++ b/xt/author/pod_coverage.t
@@ -1,2 +1,5 @@
-use Test::Pod::Coverage::TrustMe;
+use Test::More;
+eval "use Test::Pod::Coverage::TrustMe";
+plan skip_all => "Test::Pod::Coverage::TrustMe required for testing pod coverage" if $@;
+plan tests => 1;
 all_pod_coverage_ok($_, { require_link => 1 });


### PR DESCRIPTION
This is inline with what other Test::Pod::* modules document.